### PR TITLE
+ Dribdat

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This list can help any dev save hours or even days of development time and can a
 - [Expo](https://github.com/nealrs/expo) - An expo / table numbers app for your Devpost hackathon
 - [HELPq](https://github.com/ehzhang/HELPq) - An extensible real-time queue application, for mentorship @hackathons and classrooms
 - [Nucleus](https://github.com/hacktx/nucleus) -  A comprehensive hackathon application system that from HackTX. Built using PHP
+- [Dribdat](https://github.com/dribdat/dribdat) - Honeycomb challenge board for awesomely open hackathons. Built in Python, MIT licensed
 
 ## Free Resources
 ### General

--- a/docs/hackathon-administration.html
+++ b/docs/hackathon-administration.html
@@ -227,6 +227,19 @@
                 </a>   <p>A comprehensive hackathon application system that from HackTX. Built using PHP</p>
      
               </div>
+            </div>   
+
+            <div class="item media">
+              <div class="img">
+                <i class="icon ion-ios-cloud-outline"></i>
+              </div>
+              <div class="media-body">
+                <a class="btn btn-transp-arrow btn-primary" href="https://github.com/dribdat/dribdat">
+                  <span class="text">Dribdat</span>
+                  <span class="icon arrow-right"></span>
+                </a>   <p>Honeycomb challenge board for awesomely open hackathons. Built in Python, MIT licensed</p>
+     
+              </div>
             </div>      
           </div>
 


### PR DESCRIPTION
Great to see this repo spring back into action last month! Inspired by Devpost, Quill and the others you mentioned, I've suggested adding the [Dribdat](https://github.com/dribdat) open source hackathon administration system - it would be great if it could be added to the website. You may also be interested in the [Awesome Hackathon](https://github.com/dribdat/awesome-hackathon/blob/main/README.md) repo, which has parallels to this one.